### PR TITLE
Include links to relevant resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ SublimeLinter comes with some pre-defined keyboard shortcuts. You can customize 
 
 ## Support & Bugs
 
-Please use the debug mode and include all console output, and your settings in your bug report.
+Please use the [debug mode](http://www.sublimelinter.com/en/stable/troubleshooting.html#debug-mode)
+and include all console output, and your settings in your
+[bug report](https://github.com/SublimeLinter/SublimeLinter/issues/new).
 If your issue is specific to a particular linter, please report it on that linter's repository instead.
 
 


### PR DESCRIPTION
When looking for support, I found I had to track down the documentation to find out how to enable debug mode. This change adds two links to make it easier for the user to locate more rapidly the information.